### PR TITLE
Feature/close work order updates device compliance

### DIFF
--- a/app/src/main/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivity.java
+++ b/app/src/main/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivity.java
@@ -1,29 +1,37 @@
 package com.nashss.se.htmvault.activity;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.nashss.se.htmvault.activity.requests.CloseWorkOrderRequest;
 import com.nashss.se.htmvault.activity.results.CloseWorkOrderResult;
 import com.nashss.se.htmvault.converters.LocalDateTimeConverter;
 import com.nashss.se.htmvault.converters.ModelConverter;
+import com.nashss.se.htmvault.dynamodb.DeviceDao;
 import com.nashss.se.htmvault.dynamodb.WorkOrderDao;
+import com.nashss.se.htmvault.dynamodb.models.Device;
+import com.nashss.se.htmvault.dynamodb.models.ManufacturerModel;
 import com.nashss.se.htmvault.dynamodb.models.WorkOrder;
 import com.nashss.se.htmvault.exceptions.CloseWorkOrderNotCompleteException;
 import com.nashss.se.htmvault.metrics.MetricsPublisher;
 import com.nashss.se.htmvault.models.WorkOrderCompletionStatus;
+import com.nashss.se.htmvault.models.WorkOrderType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.inject.Inject;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class CloseWorkOrderActivity {
 
     private final WorkOrderDao workOrderDao;
+    private final DeviceDao deviceDao;
     private final MetricsPublisher metricsPublisher;
     private final Logger log = LogManager.getLogger();
 
     @Inject
-    public CloseWorkOrderActivity(WorkOrderDao workOrderDao, MetricsPublisher metricsPublisher) {
+    public CloseWorkOrderActivity(WorkOrderDao workOrderDao, DeviceDao deviceDao, MetricsPublisher metricsPublisher) {
         this.workOrderDao = workOrderDao;
+        this.deviceDao = deviceDao;
         this.metricsPublisher = metricsPublisher;
     }
 
@@ -66,10 +74,75 @@ public class CloseWorkOrderActivity {
             workOrder.setWorkOrderCompletionStatus(WorkOrderCompletionStatus.CLOSED);
 
             workOrder = workOrderDao.saveWorkOrder(workOrder);
+
+            // if it was a preventative maintenance or acceptance testing work order, update the last PM,
+            // compliance through date, and next PM
+            if (workOrder.getWorkOrderType() == WorkOrderType.ACCEPTANCE_TESTING ||
+                    workOrder.getWorkOrderType() == WorkOrderType.PREVENTATIVE_MAINTENANCE) {
+                LocalDate completionDate = LocalDate.of(completionDateTime.getYear(), completionDateTime.getMonth(),
+                        completionDateTime.getDayOfMonth());
+                updateDevice(workOrder.getControlNumber(), completionDate);
+            }
         }
 
         return CloseWorkOrderResult.builder()
                 .withWorkOrderModel(new ModelConverter().toWorkOrderModel(workOrder))
                 .build();
+    }
+
+    private void updateDevice(String controlNumber, LocalDate completionDate) {
+        Device device = deviceDao.getDevice(controlNumber);
+
+        // if the device requires routine preventative maintenance, update the compliance-through-date to
+        // 'maintenance frequency' number of months from the completion date, on the last day of that month,
+        // and additionally update the next pm due date
+        Integer maintenanceFrequency = device.getManufacturerModel().getRequiredMaintenanceFrequencyInMonths();
+        if (maintenanceFrequency != null && maintenanceFrequency > 0) {
+            LocalDate complianceThroughDate =
+                    completionDate.plusMonths(maintenanceFrequency + 1)
+                            .minusDays(completionDate.getDayOfMonth());
+            // if the proposed update to compliance-through-date is earlier than the existing compliance-through-date,
+            // it remains the later date. otherwise, update it.
+            if (!(null == device.getComplianceThroughDate())) {
+                int comparison = complianceThroughDate.compareTo(device.getComplianceThroughDate());
+                if (comparison > 0) {
+                    device.setComplianceThroughDate(complianceThroughDate);
+                }
+            } else {
+                device.setComplianceThroughDate(complianceThroughDate);
+            }
+
+            // update the next pm due date to 'maintenance frequency' number of months from the current pm due
+            // date, or the compliance-through-date, whichever is sooner. this allows the normal schedule to be
+            // maintained, unless the new compliance-through-date does not allow for it.
+            //
+            // for example, if the routine maintenance is normally done every 12 months in january, but the
+            // maintenance was done in february because the device was in disrepair and awaiting parts until
+            // then, the new compliance date would be the following february, but the next pm will still advance
+            // to next january, so the department-based schedule is maintained.
+            LocalDate nextPmDate = device.getNextPmDueDate() == null ? device.getComplianceThroughDate() :
+                    device.getNextPmDueDate().plusMonths(maintenanceFrequency + 1);
+            int month = nextPmDate.getMonthValue() - 1;
+            while(nextPmDate.getMonthValue() > month) {
+                nextPmDate = nextPmDate.minusDays(1);
+            }
+
+            int comparison = nextPmDate.compareTo(device.getComplianceThroughDate());
+
+            if (comparison > 0) {
+                nextPmDate = complianceThroughDate;
+            }
+
+            device.setNextPmDueDate(nextPmDate);
+        }
+
+        // now we can update the last pm completion date, if it's not sooner that the current last pm completion date
+        int comparison = null == device.getLastPmCompletionDate() ? 1 :
+                completionDate.compareTo(device.getLastPmCompletionDate());
+        if (comparison > 0) {
+            device.setLastPmCompletionDate(completionDate);
+        }
+
+        deviceDao.saveDevice(device);
     }
 }

--- a/app/src/main/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivity.java
+++ b/app/src/main/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivity.java
@@ -141,11 +141,11 @@ public class CloseWorkOrderActivity {
             // will still advance to next january, so the department-based schedule (every january) is maintained.
             //
             // however, as a different example, if the work order in question that we're basing potential changes on
-            // is completed in mid-cycle (i.e. in June 2023 for some reason, even though one was already done at the normal
-            // time in January 2023), we won't auto-advance the next pm due to the following July (2024), since it's
-            // normally done with everything else in the given department in January. if desired, the user can manually
-            // reschedule to another month up to and including the compliance-through-date of July 2024, through a
-            // separate process to be implemented for manually updating a device's next pm due date
+            // is completed in mid-cycle (i.e. in June 2023 for some reason, even though one was already done at the
+            // normal time in January 2023), we won't auto-advance the next pm due to the following June (2024), since
+            // it's normally done with everything else in the given department in January. if desired, the user can
+            // manually reschedule to another month up to and including the compliance-through-date of June 2024,
+            // through a separate process to be implemented for manually updating a device's next pm due date
 
             // if the next pm due date is null (should not be the case if the device requires maintenance, but we will
             // be defensive), there is no comparison to make - we'll sync maintenance with the

--- a/app/src/main/java/com/nashss/se/htmvault/activity/UpdateDeviceActivity.java
+++ b/app/src/main/java/com/nashss/se/htmvault/activity/UpdateDeviceActivity.java
@@ -160,21 +160,10 @@ public class UpdateDeviceActivity {
                         device.setNextPmDueDate(device.getComplianceThroughDate());
                     }
                 }
-            // a pm is required, but has never been done, so it's due now (if not already set)
+            // a pm is required, but has never been done, so it's been due since the add date
             } else {
                 device.setComplianceThroughDate(null);
-
-                LocalDate dueDate = LocalDate.now();
-                LocalDate dueDateNoNanos = LocalDate.of(dueDate.getYear(), dueDate.getMonth(),
-                        dueDate.getDayOfMonth());
-                if (null == device.getNextPmDueDate()) {
-                    device.setNextPmDueDate(dueDateNoNanos);
-                } else {
-                    int comparison = device.getNextPmDueDate().compareTo(dueDateNoNanos);
-                    if (comparison > 0) {
-                        device.setNextPmDueDate(dueDateNoNanos);
-                    }
-                }
+                device.setNextPmDueDate(device.getInventoryAddDate());
             }
         }
 

--- a/app/src/main/java/com/nashss/se/htmvault/activity/UpdateDeviceActivity.java
+++ b/app/src/main/java/com/nashss/se/htmvault/activity/UpdateDeviceActivity.java
@@ -134,11 +134,14 @@ public class UpdateDeviceActivity {
             if (!(null == device.getLastPmCompletionDate())) {
                 // set the next compliance through date to the last day of the month, "maintenance frequency" number of
                 // months after the month in which the last pm was completed
+
+                // one month past the updated compliance month
                 LocalDate updatedComplianceThroughDate =
                         device.getLastPmCompletionDate()
                                 .plusMonths(requiredMaintenanceFrequencyInMonths + 1);
                 int month = updatedComplianceThroughDate.getMonthValue() - 1;
                 int year = updatedComplianceThroughDate.getYear() - 1;
+                // subtract days to reach the last day of the previous calendar month
                 while(updatedComplianceThroughDate.getMonthValue() > month &&
                         updatedComplianceThroughDate.getYear() > year) {
                     updatedComplianceThroughDate = updatedComplianceThroughDate.minusDays(1);
@@ -157,12 +160,21 @@ public class UpdateDeviceActivity {
                         device.setNextPmDueDate(device.getComplianceThroughDate());
                     }
                 }
-            // a pm is required, but has never been done, so it's due now
+            // a pm is required, but has never been done, so it's due now (if not already set)
             } else {
                 device.setComplianceThroughDate(null);
 
                 LocalDate dueDate = LocalDate.now();
-                device.setNextPmDueDate(LocalDate.of(dueDate.getYear(), dueDate.getMonth(), dueDate.getDayOfMonth()));
+                LocalDate dueDateNoNanos = LocalDate.of(dueDate.getYear(), dueDate.getMonth(),
+                        dueDate.getDayOfMonth());
+                if (null == device.getNextPmDueDate()) {
+                    device.setNextPmDueDate(dueDateNoNanos);
+                } else {
+                    int comparison = device.getNextPmDueDate().compareTo(dueDateNoNanos);
+                    if (comparison > 0) {
+                        device.setNextPmDueDate(dueDateNoNanos);
+                    }
+                }
             }
         }
 

--- a/app/src/test/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivityTest.java
+++ b/app/src/test/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivityTest.java
@@ -37,10 +37,6 @@ class CloseWorkOrderActivityTest {
     private DynamoDBMapper dynamoDBMapper;
     @Mock
     private MetricsPublisher metricsPublisher;
-    @Mock
-    private WorkOrderDao workOrderDaoMaintenanceStatUpdates;
-    @Mock
-    private DeviceDao deviceDaoMaintenanceStatUpdates;
 
     private CloseWorkOrderActivity closeWorkOrderActivity;
 

--- a/app/src/test/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivityTest.java
+++ b/app/src/test/java/com/nashss/se/htmvault/activity/CloseWorkOrderActivityTest.java
@@ -421,6 +421,51 @@ class CloseWorkOrderActivityTest {
         assertEquals(copyDevice, result);
     }
 
+    @Test
+    public void advanceMaintenanceStatsWithWorkOrderIfApplicable_willAdvanceComplianceDate_updatesCompliance() {
+        // GIVEN
+        ManufacturerModel manufacturerModel = new ManufacturerModel();
+        manufacturerModel.setManufacturer("TestManufacturer");
+        manufacturerModel.setModel("TestModel");
+        manufacturerModel.setRequiredMaintenanceFrequencyInMonths(12);
+        WorkOrder workOrder = WorkOrderTestHelper.generateWorkOrder(1, "123",
+                "G321", manufacturerModel, "TestFacility", "TestDepartment");
+        workOrder.setWorkOrderCompletionStatus(WorkOrderCompletionStatus.CLOSED);
+        workOrder.setWorkOrderType(WorkOrderType.PREVENTATIVE_MAINTENANCE);
+        workOrder.setWorkOrderAwaitStatus(WorkOrderAwaitStatus.AWAITING_PARTS);
+        workOrder.setProblemFound("a problem found");
+        workOrder.setSummary("a summary");
+        workOrder.setCompletionDateTime(new LocalDateTimeConverter()
+                .unconvert("2023-06-15T10:00:01"));
+        workOrder.setClosedById(workOrder.getCreatedById());
+        workOrder.setClosedByName(workOrder.getCreatedByName());
+        workOrder.setClosedDateTime(workOrder.getCreationDateTime().plusHours(1));
+
+        // a device with a last pm completed 6/15/2022, so the next pm and compliance-through-date
+        // are 6/30/2023. we are attempting to update maintenance stats with a pm completed 6/15/2023,
+        // which would cause the compliance-through-date to advance, so we expect it should update to
+        // 6/30/2024
+        Device device = DeviceTestHelper.generateActiveDevice(1, manufacturerModel,
+                "TestFacility", "TestDepartment");
+        device.setComplianceThroughDate(LocalDate.of(2023, 6, 30));
+        device.setLastPmCompletionDate(LocalDate.of(2022, 6, 12));
+        device.setNextPmDueDate(LocalDate.of(2023, 6, 30));
+
+        when(dynamoDBMapper.load(eq(WorkOrder.class), anyString())).thenReturn(workOrder);
+        when(dynamoDBMapper.load(eq(Device.class), anyString())).thenReturn(device);
+
+        Device copyDevice = copyDevice(device);
+        copyDevice.setComplianceThroughDate(LocalDate.of(2024, 6, 30));
+        copyDevice.setNextPmDueDate(LocalDate.of(2024, 6, 30));
+        copyDevice.setLastPmCompletionDate(LocalDate.of(2023, 6, 15));
+
+        // WHEN
+        Device result = closeWorkOrderActivity.advanceMaintenanceStatsWithWorkOrderIfApplicable("WR123");
+
+        // THEN
+        assertEquals(copyDevice, result);
+    }
+
     private WorkOrder copyWorkOrder(WorkOrder workOrder) {
         WorkOrder copyWorkOrder = new WorkOrder();
         copyWorkOrder.setWorkOrderId(workOrder.getWorkOrderId());

--- a/app/src/test/java/com/nashss/se/htmvault/activity/RetireDeviceActivityTest.java
+++ b/app/src/test/java/com/nashss/se/htmvault/activity/RetireDeviceActivityTest.java
@@ -1,5 +1,6 @@
 package com.nashss.se.htmvault.activity;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.nashss.se.htmvault.activity.requests.RetireDeviceRequest;
 import com.nashss.se.htmvault.activity.results.RetireDeviceResult;
 import com.nashss.se.htmvault.dynamodb.DeviceDao;
@@ -78,8 +79,12 @@ class RetireDeviceActivityTest {
                 .withCustomerId("an ID")
                 .withCustomerName("a name")
                 .build();
-        when(deviceDao.getDevice("123")).thenReturn(device);
-        when(workOrderDao.getWorkOrders(anyString())).thenThrow(RetireDeviceWithOpenWorkOrdersException.class);
+
+        WorkOrder workOrder = WorkOrderTestHelper.generateWorkOrder(1, "123",
+                "G321", manufacturerModel, "TestManufacturer", "TestModel");
+        workOrder.setWorkOrderCompletionStatus(WorkOrderCompletionStatus.OPEN);
+        when(deviceDao.getDevice(anyString())).thenReturn(device);
+        when(workOrderDao.getWorkOrders(anyString())).thenReturn(new ArrayList<>(List.of(workOrder)));
 
         // WHEN & THEN
         assertThrows(RetireDeviceWithOpenWorkOrdersException.class, () ->

--- a/app/src/test/java/com/nashss/se/htmvault/dynamodb/DeviceDaoTest.java
+++ b/app/src/test/java/com/nashss/se/htmvault/dynamodb/DeviceDaoTest.java
@@ -1,16 +1,29 @@
 package com.nashss.se.htmvault.dynamodb;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.nashss.se.htmvault.converters.ManufacturerModelConverter;
 import com.nashss.se.htmvault.dynamodb.models.Device;
+import com.nashss.se.htmvault.dynamodb.models.ManufacturerModel;
+import com.nashss.se.htmvault.dynamodb.models.WorkOrder;
 import com.nashss.se.htmvault.exceptions.DeviceNotFoundException;
+import com.nashss.se.htmvault.exceptions.DevicePreviouslyAddedException;
 import com.nashss.se.htmvault.metrics.MetricsConstants;
 import com.nashss.se.htmvault.metrics.MetricsPublisher;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.nashss.se.htmvault.test.helper.DeviceTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -24,6 +37,8 @@ class DeviceDaoTest {
     private DynamoDBMapper dynamoDBMapper;
     @Mock
     private MetricsPublisher metricsPublisher;
+    @Mock
+    private PaginatedQueryList<Device> queryList;
 
     @InjectMocks
     private DeviceDao deviceDao;
@@ -74,5 +89,76 @@ class DeviceDaoTest {
                         "DeviceNotFoundException thrown");
         verify(dynamoDBMapper).load(Device.class, controlNumber);
         verify(metricsPublisher).addCount(MetricsConstants.GETDEVICE_DEVICENOTFOUND_COUNT, 1);
+    }
+
+    @Test
+    public void checkDevicePreviouslyAdded_deviceFound_throwsDevicePreviouslyAddedException() {
+        // GIVEN
+        String serialNumber = "G321";
+
+        ManufacturerModel manufacturerModel = new ManufacturerModel();
+        manufacturerModel.setManufacturer("Monitor Co.");
+        manufacturerModel.setModel("Their First Monitor Model");
+        manufacturerModel.setRequiredMaintenanceFrequencyInMonths(12);
+
+        // an array of, for this test, one mocked "matching" device found in the database for the "new"
+        // device we are trying to add with serial number, manufacturer, and model, so we should not be able to add it
+        // "again" (an exception should be thrown)
+        Device[] deviceArray = new Device[1];
+        deviceArray[0] = new Device();
+
+        // mocked paginated query list to return
+        when(dynamoDBMapper.query(eq(Device.class), any(DynamoDBQueryExpression.class))).thenReturn(queryList);
+
+        // mocked device array to return when the arraylist constructor attempts to convert the mocked
+        // paginated query list
+        when(queryList.toArray()).thenReturn(deviceArray);
+
+        // captor for the query expression invoked when we call the method under test
+        ArgumentCaptor<DynamoDBQueryExpression<Device>> captor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+
+        // WHEN & THEN
+        assertThrows(DevicePreviouslyAddedException.class, () ->
+                deviceDao.checkDevicePreviouslyAdded(manufacturerModel, serialNumber),
+                "Expected attempting to create/add a new device that matches one already" +
+                        "in the database by serial number and manufacturer/model to result in a" +
+                        "DevicePreviouslyAddedException thrown");
+
+        // capture the query expression used in the mapper.query argument
+        verify(dynamoDBMapper).query(eq(Device.class), captor.capture());
+
+        // obtain the queryExpression (value) contained in our captured argument
+        DynamoDBQueryExpression<Device> queryExpression = captor.getValue();
+
+        // obtain each specific value the query expression was built with
+        String queriedIndexName = queryExpression.getIndexName();
+
+        Map<String, AttributeValue> queriedExpressionAttributes = queryExpression.getExpressionAttributeValues();
+        Collection<AttributeValue> expressionAttributeValues = queriedExpressionAttributes.values();
+        Set<String> expressionAttributeKeys = queriedExpressionAttributes.keySet();
+
+        String queriedKeyConditionExpression = queryExpression.getKeyConditionExpression();
+
+        boolean queriedConsistentRead = queryExpression.isConsistentRead();
+
+        // verify the expected query expression values
+        assertEquals(Device.MANUFACTURER_MODEL_SERIAL_NUMBER_INDEX, queriedIndexName, "Expected query " +
+                "expression to query with global secondary index name: " +
+                Device.MANUFACTURER_MODEL_SERIAL_NUMBER_INDEX + ", but was: " + queriedIndexName);
+
+        assertTrue(expressionAttributeValues.contains(new AttributeValue(serialNumber)), "Expected query " +
+                "expression to set serial number to " + serialNumber + "in expression attribute values");
+        assertTrue(expressionAttributeValues.contains(new AttributeValue().withS(new ManufacturerModelConverter()
+                        .convert(manufacturerModel))),
+                "Expected query expression to set manufacturer model to " + manufacturerModel + "in " +
+                        "expression attribute values");
+
+        for (String key : expressionAttributeKeys) {
+            assertTrue(queriedKeyConditionExpression.contains(key), "Expected query expression to " +
+                    "reference key set in expression attribute values");
+        }
+
+        assertFalse(queriedConsistentRead, "Expected query expression to query with consistent reads set " +
+                "false");
     }
 }


### PR DESCRIPTION
# Description

Modified close-work-order-activity to additionally update device compliance-through-date, last-pm-completion-date, and next-pm-due-date if applicable (i.e. work order was a preventative maintenance, as opposed to a repair).

Modified update-device-activity logic for updating compliance-through-date and next-pm-due-date as applicable based on changes to pm frequency (i.e. the manufacturer-model is corrected to one that has a maintenance frequency of 6 months instead of 12)

Unit test updates for changes to activity classes; additionally updated retire-device-activity unit test and added device-dao unit test for increased code test coverage