### PR TITLE
Feature/front end navigation updates

### DIFF
--- a/web/src/pages/viewWorkOrder.js
+++ b/web/src/pages/viewWorkOrder.js
@@ -183,6 +183,13 @@ class ViewWorkOrder extends BindingClass {
         updateWorkOrderDiv.classList.remove('hidden');
     }
 
+    async cancelUpdatesWorkOrder() {
+        const workOrderDiv = document.getElementById('work-order-display-div');
+        const updateWorkOrderDiv = document.getElementById('update-work-order-form-div');
+        updateWorkOrderDiv.classList.add('hidden');
+        workOrderDiv.classList.remove('hidden');
+    }
+
     async clientLoaded() {
         const urlParams = new URLSearchParams(window.location.search);
         const workOrderId = urlParams.get('workOrderId');
@@ -236,6 +243,7 @@ class ViewWorkOrder extends BindingClass {
         document.getElementById('update-work-order').addEventListener('click', this.displayUpdateWorkOrderForm);
         document.getElementById('submit-updates-work-order').addEventListener('click', this.submitUpdatesWorkOrder);
         document.getElementById('close-work-order').addEventListener('click', this.closeWorkOrder);
+        document.getElementById('cancel-updates-work-order').addEventListener('click', this.cancelUpdatesWorkOrder);
 
         this.header.addHeaderToPage();
 

--- a/web/src/pages/viewWorkOrder.js
+++ b/web/src/pages/viewWorkOrder.js
@@ -215,7 +215,7 @@ class ViewWorkOrder extends BindingClass {
 
         document.getElementById('work-order-id').innerText = workOrder.workOrderId;
         document.getElementById('work-order-type').innerText = workOrder.workOrderType;
-        document.getElementById('control-number').innerHTML = `<a href="device.html?controlNumber=${workOrder.controlNumber}">${workOrder.controlNumber}</a>`;
+        document.getElementById('control-number').innerHTML = `<a href="device.html?controlNumber=${workOrder.controlNumber}&order=DESCENDING">${workOrder.controlNumber}</a>`;
         document.getElementById('serial-number').innerText = workOrder.serialNumber;
         document.getElementById('completion-status').innerText = workOrder.workOrderCompletionStatus;
         if (workOrder.workOrderCompletionStatus == "CLOSED") {

--- a/web/src/pages/viewWorkOrder.js
+++ b/web/src/pages/viewWorkOrder.js
@@ -215,7 +215,7 @@ class ViewWorkOrder extends BindingClass {
 
         document.getElementById('work-order-id').innerText = workOrder.workOrderId;
         document.getElementById('work-order-type').innerText = workOrder.workOrderType;
-        document.getElementById('control-number').innerText = workOrder.controlNumber;
+        document.getElementById('control-number').innerHTML = `<a href="device.html?controlNumber=${workOrder.controlNumber}">${workOrder.controlNumber}</a>`;
         document.getElementById('serial-number').innerText = workOrder.serialNumber;
         document.getElementById('completion-status').innerText = workOrder.workOrderCompletionStatus;
         if (workOrder.workOrderCompletionStatus == "CLOSED") {

--- a/web/static_assets/device.html
+++ b/web/static_assets/device.html
@@ -12,8 +12,11 @@
     <h2>Device Record</h2>
     <p class="hidden error" id="error-message-device-record-change"></p>
     <p class="hidden success" id="success-message"></p>
-    <a href="#" class="button" id="retire-device">Retire Device</a>
-    <a href="#" class="button" id="reactivate-device">Reactivate Device</a>
+    <p class="button-group">
+        <a href="#" class="button" id="retire-device">Retire Device</a>
+        <a href="#" class="button" id="reactivate-device">Reactivate Device</a>
+        <a href="addDevice.html" class="button">Add Device</a>
+    </p>
     <a href="#" class="button" id="update-device">Update Device</a>
     <h3 id="device-record"></h3>
     <h4>Control Number: <span id="control-number"></span></h4>

--- a/web/static_assets/workOrder.html
+++ b/web/static_assets/workOrder.html
@@ -39,6 +39,7 @@
         <h2>Update Work Order</h2>
         <form class="card-content" id="update-work-order-form">
             <p class="hidden error" id="update-work-order-error-message"></p>
+            <a href="#" class="button" id="cancel-updates-work-order">Cancel</a>
             <h4>Work Order ID: <span id="updating-work-order-id"></span></h4>
             <p class="form-field">
                 <label for="workOrderType">Work Order Type</label>


### PR DESCRIPTION
# Description

- Added cancel update work order button/functionality
- Added link from work order details page to device record page using work order control number (device ID)
- Added button/functionality to redirect to add new device form directly on device details page (in addition to the button on the home page). This avoids the need to go back to the home page first, between adds.